### PR TITLE
Fix job cleanup by properly canceling SLURM jobs on interruption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slrun"  # Changed from "slurm-tools" to "slrun"
-version = "0.1.1"
+version = "0.1.2"
 description = "Run commands on SLURM as if local with seamless detach/reattach"
 readme = "README.md"
 authors = [

--- a/src/slrun/__init__.py
+++ b/src/slrun/__init__.py
@@ -1,3 +1,3 @@
 """Tools for running commands on SLURM as if local."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/slrun/slrun.py
+++ b/src/slrun/slrun.py
@@ -196,6 +196,14 @@ def attach_to_job(job_id):
         if signum:
             print(f"\nInterrupted, cleaning up...", file=sys.stderr)
         if not detached:  # Only clean up if we didn't detach
+            # First cancel the SLURM job
+            print(f"Canceling job {job_id}...", file=sys.stderr)
+            subprocess.run(['scancel', job_id], stderr=subprocess.DEVNULL)
+            
+            # Wait a moment for SLURM to process the cancellation
+            time.sleep(1)
+            
+            # Then clean up files
             shutil.rmtree(temp_dir, ignore_errors=True)
             remove_job_info(job_id)
         if signum:
@@ -308,6 +316,16 @@ def launch_job(args):
         if signum:
             print(f"\nInterrupted, cleaning up...", file=sys.stderr)
         if not detached:  # Only clean up if we didn't detach
+            # First cancel the SLURM job if it exists
+            if 'job_id' in locals() or 'job_id' in globals():
+                print(f"Canceling job {job_id}...", file=sys.stderr)
+                subprocess.run(['scancel', job_id], stderr=subprocess.DEVNULL)
+                # Wait a moment for SLURM to process the cancellation
+                time.sleep(1)
+                # Remove job info file
+                remove_job_info(job_id)
+            
+            # Then clean up temporary directory
             shutil.rmtree(temp_dir, ignore_errors=True)
         if signum:
             sys.exit(128 + signum)


### PR DESCRIPTION
## Issue
Fixes #1 

When interrupting slrun during job attachment or launch, the cleanup process was removing local files but not terminating the actual SLURM job. This left orphaned jobs running in the cluster.

## Changes
- Added explicit job cancellation to cleanup functions in both attach_to_job and launch_job
- Added a short delay after cancellation to ensure SLURM has time to process it
- Added checks to ensure job_id exists before attempting cancellation
- Bumped version from 0.1.1 to 0.1.2

## Testing
Tested the fix by:
1. Launching a job with slrun and interrupting with Ctrl+C
2. Launching a job, detaching, then reattaching and interrupting

In both cases, the SLURM job is now properly canceled and disappears from the queue.